### PR TITLE
Support for reading the values of assembly info file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ gulp.task('assemblyInfo', function() {
 });
 ```
 
+You can also use the plugin to read the data from assembly info file:
+
+```js
+var gulp = require('gulp'),
+     fs = require('fs'),
+    assemblyInfo = require('gulp-dotnet-assembly-info');
+
+gulp.task('readAssemblyInfo', function () {
+
+    var assemblyInfoFileContents = fs.readFileSync('./properties/AssemblyInfo.cs', "utf8");
+    var assembly = assemblyInfo.getAssemblyMetadata(assemblyInfoFileContents);
+    console.log("Current version is: " + assembly.AssemblyVersion);
+    
+});
+
+```
+
 ## Props
 
 Thanks to [Diego Luces](https://github.com/dluces) for adding VB.NET support.

--- a/plugin.js
+++ b/plugin.js
@@ -1,5 +1,6 @@
 var through = require('through2'),
     gulp = require('gulp-util'),
+    fs = require('fs'),
     PluginError = gulp.PluginError;
 
 var PLUGIN_NAME = 'gulp-dotnet-assembly-info';
@@ -52,4 +53,38 @@ function assemblyInfo(config) {
     return stream;
 }
 
+assemblyInfo.getAssemblyMetadataFromFileSync = function(filePath){
+    
+    var assemblyInfoFileContent = fs.readFileSync(filepath, "utf8");
+
+    return assemblyInfo.getAssemblyMetadata(assemblyInfoFileContent)
+}
+
+assemblyInfo.getAssemblyMetadata = function(assemblyInfoFileContent){
+    
+    var regex = new RegExp('^\\s*[\\[<]\\s*[aA]ssembly\\s*:\\s*(\\s*[a-zA-Z][^(\\s]+)\\s*\\(\\s*([^)]+)\\s*\\)\\s*[\\]>]', 'gm');
+
+    var regex = /^\s*[\[<]\s*[aA]ssembly\s*:\s*(\s*[a-zA-Z][^(\s]+)\s*\(\s*([^)]+)\s*\)\s*[\]>]/gm;
+        
+    var output = {};
+    while ((m = regex.exec(assemblyInfoFileContent)) !== null) {
+        if (m.index === regex.lastIndex) {
+            regex.lastIndex++;
+        }
+        var value = m[2].trim();
+        
+        if(value.toLowerCase() === 'true'){
+            value = true;
+        }
+        else if(value.toLowerCase()  === 'false'){ 
+            value = false;
+        }
+        else if (value.charAt(0) === '"' && value.charAt(value.length - 1) === '"'){
+            value = value.substr(1, value.length -2);
+        }
+        
+        output[m[1]] = value;
+    }
+    return output;
+}
 module.exports = assemblyInfo;

--- a/test/spec.js
+++ b/test/spec.js
@@ -10,12 +10,20 @@ describe('gulp-dotnet-assembly-info', function() {
         'using System.Reflection;\r\n\r\n' +
         '// General Information about an assembly is controlled through the following \r\n\r\n' +
         '[   assembly   :   AssemblyTitle  (   "{{title}}" )  ]\r\n' +
-        '[assembly:AssemblyDescription("{{description}}")]');
+        '[assembly:AssemblyDescription("{{description}}")]\r\n' +
+        '// Commented out entries should be ignored:\r\n' +
+        '// [assembly: AssemblyConfiguration("")]\r\n' +
+        '[assembly: ComVisible(false)]'
+        );
     var vbAssemblyInfoTemplate = Handlebars.compile(
         'Imports System.Reflection;\r\n\r\n' +
         '// General Information about an assembly is controlled through the following \r\n\r\n' +
         '<   assembly   :   AssemblyTitle  (   "{{title}}" )  >\r\n' +
-        '<Assembly:AssemblyDescription("{{description}}")>');
+        '<Assembly:AssemblyDescription("{{description}}")>\r\n' + 
+        '\' Commented out entries should be ignored:\r\n' +
+        '\' <Assembly: AssemblyConfiguration("")>\r\n' +
+        '<Assembly: ComVisible(False)>'
+        );
     var defaultTitle = 'some title';
     var defaultDescription = 'some description';
     var defaultAssemblyInfoFilePath = '/Solution/Project/Project.csproj';
@@ -117,4 +125,29 @@ describe('gulp-dotnet-assembly-info', function() {
 
     });
 
+    it('should read C# assembly info file', function(done) {
+
+        var info = assemblyInfo.getAssemblyMetadata(csAssemblyInfo.contents)
+
+        console.log(info);
+        expect(info).to.be.an('object');
+        expect(info).to.have.property('AssemblyTitle', defaultTitle)
+        expect(info).to.have.property('AssemblyDescription', defaultDescription)
+        expect(info).to.have.property('ComVisible', false)
+        expect(info).to.not.have.property('AssemblyConfiguration')
+        done();
+    });
+    
+    it('should read VB assembly info file', function(done) {
+
+        var info = assemblyInfo.getAssemblyMetadata(vbAssemblyInfo.contents)
+
+        console.log(info);
+        expect(info).to.be.an('object');
+        expect(info).to.have.property('AssemblyTitle', defaultTitle)
+        expect(info).to.have.property('AssemblyDescription', defaultDescription)
+        expect(info).to.have.property('ComVisible', false)
+        expect(info).to.not.have.property('AssemblyConfiguration')
+        done();
+    });
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -129,7 +129,6 @@ describe('gulp-dotnet-assembly-info', function() {
 
         var info = assemblyInfo.getAssemblyMetadata(csAssemblyInfo.contents)
 
-        console.log(info);
         expect(info).to.be.an('object');
         expect(info).to.have.property('AssemblyTitle', defaultTitle)
         expect(info).to.have.property('AssemblyDescription', defaultDescription)
@@ -142,7 +141,6 @@ describe('gulp-dotnet-assembly-info', function() {
 
         var info = assemblyInfo.getAssemblyMetadata(vbAssemblyInfo.contents)
 
-        console.log(info);
         expect(info).to.be.an('object');
         expect(info).to.have.property('AssemblyTitle', defaultTitle)
         expect(info).to.have.property('AssemblyDescription', defaultDescription)


### PR DESCRIPTION
I've added a function for reading of the values in assembly info file. This can be useful if anyone wants to have some logic based on actual values before actually modifying of the assembly info.

I'm not a gulp expert, so be careful with that :) Any feedback would be appreciated, especially on how to plug that into the gulp infrastructure.
